### PR TITLE
Fix actor stat click rolls

### DIFF
--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -786,7 +786,7 @@ export class RyuutamaActorSheet extends ActorSheet {
                             modifiers.push(concentrationBonus);
                             checkText = `${actor.name} ${game.i18n.localize("RYUU.checkint")} [INT + INT]<br /><strong>CONCENTRATING</strong>`;
                         }
-                        rollCheck(`2d${dex}`, `${checkText}${currentModifiers}`, modifiers);
+                        rollCheck(`2d${int}`, `${checkText}${currentModifiers}`, modifiers);
                     }
                     break;
                 }
@@ -800,7 +800,7 @@ export class RyuutamaActorSheet extends ActorSheet {
                             modifiers.push(concentrationBonus);
                             checkText = `${actor.name} ${game.i18n.localize("RYUU.checkspi")} [SPI + SPI]<br /><strong>CONCENTRATING</strong>`;
                         }
-                        rollCheck(`2d${dex}`, `${checkText}${currentModifiers}`, modifiers);
+                        rollCheck(`2d${spi}`, `${checkText}${currentModifiers}`, modifiers);
                     }
                     break;
                 }


### PR DESCRIPTION
Intelligence and spirit were rolling 2d${dex} instead of int and spi.
This closes #65 and closes #66.